### PR TITLE
Fixed BIP32/BIP39 Implementation

### DIFF
--- a/BRBIP32Sequence.c
+++ b/BRBIP32Sequence.c
@@ -28,7 +28,7 @@
 #include <string.h>
 #include <assert.h>
 
-#define BIP32_SEED_KEY "DigiByte seed"
+#define BIP32_SEED_KEY "Bitcoin seed"
 #define BIP32_XPRV     "\x04\x88\xAD\xE4"
 #define BIP32_XPUB     "\x04\x88\xB2\x1E"
 


### PR DESCRIPTION
Current implementation of master seed was wrong from standards. This causes a problem especially for DigiID because anyone using DigiByte mobile would never be able to move to a new wallet should the wallet become unusable.

To fix and not break old wallets I recommend abandoning existing apps and create a new app maybe called DigiByte Universal or maybe if possible change old apps name to DigiByte(Deprecated)

This will create inconvenience for users as they move over to new app to get upgrades but in the long run would allow a much safer and more reliable user experience.

While at it would be a good time to change path from m/0' to the BIP44 standard of m/44'/20'/0'