### PR TITLE
Update DigiByte Seed Nodes

### DIFF
--- a/BRChainParams.h
+++ b/BRChainParams.h
@@ -46,10 +46,20 @@ typedef struct {
 } BRChainParams;
 
 static const char *BRMainNetDNSSeeds[] = {
-        "digiexplorer.info",
-        "dgb1.trezor.io",
-        "digibyteblockexplorer.com",
-        "digibyte.host", NULL
+        "seed.digibyte.io", // Jared Tate
+        "seed.digihash.co", // Jared Tate
+        "dnsseed.esotericizm.site", // DigiContributor
+        "seed.digiexplorer.info", // DigiByte Foundation
+        "seed.digiassets.net", // DigiByte Foundation
+        "digibyteblockexplorer.com", // DigiByte Block Explorer
+        "dgb1.trezor.io", // Trezor
+        "seed2.digibyte.io", // Jared Tate
+        "seed3.digibyte.io", // Jared Tate
+        "seed.digibyteblockchain.com", // JS555
+        "seed.digibyte.host", // SashaD
+        "seed.digibytefoundation.org", // DigiByte Foundation
+        "seed.digibyte.org", // Website collective
+        "seed.digibyteservers.io", NULL // ChillingSilence
 };
 
 static const char *BRTestNetDNSSeeds[] = {

--- a/BRChainParams.h
+++ b/BRChainParams.h
@@ -59,7 +59,9 @@ static const char *BRMainNetDNSSeeds[] = {
         "seed.digibyte.host", // SashaD
         "seed.digibytefoundation.org", // DigiByte Foundation
         "seed.digibyte.org", // Website collective
-        "seed.digibyteservers.io", NULL // ChillingSilence
+        "seed.digibyteservers.io",
+        "dgb.quakeguy.com", // Quakeitup
+        NULL // ChillingSilence
 };
 
 static const char *BRTestNetDNSSeeds[] = {


### PR DESCRIPTION
Signed-off-by: Jared Tate <13957390+JaredTate@users.noreply.github.com>

After looking through the hardcoded seed nodes for DigiByte-Core as well as digibytewallet-core for the mobile wallets both codebases need to be updated with more seeds to help fix connection issues now being experienced, especially the light wallets.

Running a DGB core seed node is simple. You just need to have a URL (example: seed.digibyte.io) and a DigiByte Core full node of the latest version that's running 24/7 at that address. It's also helpful to add "maxconnections=800" or any higher number to allow more than 8 peers at a time in the digibyte.conf file.

If you are interested in running a full-time seed node for the next few years to help the network out please mention it in a comment below with the URL. Let me know if you see any issues with seeds listed below.

These seeds are working great: 

```
static const char *BRMainNetDNSSeeds[] = {
        "seed.digibyte.io", // Jared Tate
        "seed.digihash.co", // Jared Tate
        "dnsseed.esotericizm.site", // DigiContributor
        "seed.digiexplorer.info", // DigiByte Foundation
        "seed.digiassets.net", // DigiByte Foundation
        "digibyteblockexplorer.com", // DigiByte Block Explorer
        "dgb1.trezor.io", // Trezor
        "seed2.digibyte.io", // Jared Tate
        "seed3.digibyte.io", // Jared Tate
        "seed.digibyteblockchain.com", // JS555
        "seed.digibyte.host", // SashaD
        "seed.digibytefoundation.org", // DigiByte Foundation
        "seed.digibyte.org", // Website collective
        "seed.digibyteservers.io", NULL // ChillingSilence
};

