### PR TITLE
Update: Add new lifehash dns seed

### DIFF
--- a/BRChainParams.h
+++ b/BRChainParams.h
@@ -61,6 +61,7 @@ static const char *BRMainNetDNSSeeds[] = {
         "seed.digibyte.org", // Website collective
         "seed.digibyteservers.io",
         "dgb.quakeguy.com", // Quakeitup
+        "dnsseed.lifehash.com", // LifeHash
         NULL // ChillingSilence
 };
 


### PR DESCRIPTION
Adds a new DNS seed.

> dnsseed.lifehash.com.   2935    IN      A       87.79.94.221
dnsseed.lifehash.com.   2935    IN      A       45.147.199.15
dnsseed.lifehash.com.   2935    IN      A       136.243.78.77
dnsseed.lifehash.com.   2935    IN      A       217.72.4.157
dnsseed.lifehash.com.   2935    IN      A       75.64.212.61
dnsseed.lifehash.com.   2935    IN      A       84.197.254.149
dnsseed.lifehash.com.   2935    IN      A       119.224.62.92
dnsseed.lifehash.com.   2935    IN      A       210.56.87.126
dnsseed.lifehash.com.   2935    IN      A       212.92.101.189
dnsseed.lifehash.com.   2935    IN      A       87.98.240.205
dnsseed.lifehash.com.   2935    IN      A       101.37.90.142
dnsseed.lifehash.com.   2935    IN      A       144.91.104.184
dnsseed.lifehash.com.   2935    IN      A       47.180.49.158
dnsseed.lifehash.com.   2935    IN      A       66.194.38.250
dnsseed.lifehash.com.   2935    IN      A       142.44.212.178
dnsseed.lifehash.com.   2935    IN      A       5.9.193.21
dnsseed.lifehash.com.   2935    IN      A       134.209.100.221
dnsseed.lifehash.com.   2935    IN      A       74.14.171.169
dnsseed.lifehash.com.   2935    IN      A       143.110.159.82
dnsseed.lifehash.com.   2935    IN      A       5.9.193.22
dnsseed.lifehash.com.   2935    IN      A       173.212.245.138
dnsseed.lifehash.com.   2935    IN      A       88.134.94.58
dnsseed.lifehash.com.   2935    IN      A       170.106.37.150
dnsseed.lifehash.com.   2935    IN      A       157.90.183.39
dnsseed.lifehash.com.   2935    IN      A       159.89.126.193