### PR TITLE
Add digibyteblockchain.com DNS seeder

### DIFF
--- a/BRChainParams.h
+++ b/BRChainParams.h
@@ -49,6 +49,7 @@ static const char *BRMainNetDNSSeeds[] = {
         "seed.digibyte.io", // Jared Tate
         "seed.digibyte.org", // Website collective
         "dnsseed.lifehash.com", // LifeHash
+        "seed.digibyteblockchain.com", // JS555
         "seed.digihash.co", // Jared Tate
         "seed.digiassets.net", // DigiByte Foundation
         "digibyte.host", // SashaD


### PR DESCRIPTION
The server was set up and now is online to make sure it's consistent with the Core wallet.
